### PR TITLE
Incorporate feedback from github issues into the script

### DIFF
--- a/notebooks/CO_LiDAR_test_area.geojson
+++ b/notebooks/CO_LiDAR_test_area.geojson
@@ -1,0 +1,8 @@
+{
+"type": "FeatureCollection",
+"name": "CO_LiDAR_test_area",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+"features": [
+{ "type": "Feature", "properties": { "fid": 1 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -106.73133937023394, 38.833854571849272 ], [ -106.420198669492876, 38.837170695505556 ], [ -106.415844374389351, 38.674062817886124 ], [ -106.730967863717666, 38.67864201968726 ], [ -106.73133937023394, 38.833854571849272 ] ] ] } }
+]
+}

--- a/src/grid_pc/dsm_functions.py
+++ b/src/grid_pc/dsm_functions.py
@@ -69,10 +69,10 @@ def return_readers(input_aoi,
     return readers, pointcloud_input_crs
 
 
-def create_pdal_pipeline(filter_low_noise=True, filter_high_noise=True,
-                         filter_road=True, reset_classes=False, reclassify_ground=False,
-                         return_only_ground=False, percentile_filter=True, percentile_threshold=0.95,
-                         group_filter=None, reproject=True, save_pointcloud=False,
+def create_pdal_pipeline(filter_low_noise=False, filter_high_noise=False,
+                         filter_road=False, reset_classes=False, reclassify_ground=False,
+                         return_only_ground=False, percentile_filter=False, percentile_threshold=0.95,
+                         group_filter="first,only", reproject=True, save_pointcloud=False,
                          pointcloud_file = 'pointcloud', input_crs=None,
                          output_crs=None, output_type='laz'):
 
@@ -192,15 +192,18 @@ def create_dem_stage(dem_filename='dem_output.tif', pointcloud_resolution=1.,
             "gdalopts":"COMPRESS=LZW,TILED=YES,blockxsize=256,blockysize=256,COPY_SRC_OVERVIEWS=YES"
     }
 
-    if dimension == 'Z':
-        dem_stage.update({
-            'dimension': 'Z',
-            'where': 'Z>0'
-        })
-    else:
-        dem_stage.update({
+    dem_stage.update({
             'dimension':dimension
         })
+    #if dimension == 'Z':
+     #   dem_stage.update({
+      #      'dimension': 'Z',
+       #     'where': 'Z>0'
+       # })
+    #else:
+     #   dem_stage.update({
+      #      'dimension':dimension
+      #  })
 
     return [dem_stage]
 

--- a/src/grid_pc/pdal_pipeline.py
+++ b/src/grid_pc/pdal_pipeline.py
@@ -100,7 +100,7 @@ def create_dsm(extent_geojson: str, # processing_extent.geojson
         dem_file = output_path / f'dem_tile_aoi_{str(i).zfill(4)}.tif'
         pipeline = {'pipeline':[reader]}
 
-        pdal_pipeline = dsm_functions.create_pdal_pipeline(
+        pdal_pipeline_dsm = dsm_functions.create_pdal_pipeline(
             filter_low_noise=FILTER_LOW_NOISE,
             filter_high_noise=FILTER_HIGH_NOISE,
             filter_road=FILTER_ROAD,
@@ -116,6 +116,36 @@ def create_dsm(extent_geojson: str, # processing_extent.geojson
             output_type=OUTPUT_TYPE
         )
 
+        pdal_pipeline_dtm = dsm_functions.create_pdal_pipeline(
+            filter_low_noise=FILTER_LOW_NOISE,
+            filter_high_noise=FILTER_HIGH_NOISE,
+            filter_road=FILTER_ROAD,
+            reset_classes=RESET_CLASSES, reclassify_ground=RECLASSIFY_GROUND,
+            return_only_ground=RETURN_ONLY_GROUND,
+            percentile_filter=PERCENTILE_FILTER, percentile_threshold=PERCENTILE_THRESHOLD,
+            group_filter=last,only,
+            reproject=REPROJECT,
+            save_pointcloud=SAVE_POINTCLOUD,
+            pointcloud_file='pointcloud',
+            input_crs = POINTCLOUD_CRS[i],
+            output_crs=OUTPUT_CRS,
+            output_type=OUTPUT_TYPE
+        )
+        pdal_pipeline_surface_intesity = dsm_functions.create_pdal_pipeline(
+            filter_low_noise=FILTER_LOW_NOISE,
+            filter_high_noise=FILTER_HIGH_NOISE,
+            filter_road=FILTER_ROAD,
+            reset_classes=RESET_CLASSES, reclassify_ground=RECLASSIFY_GROUND,
+            return_only_ground=RETURN_ONLY_GROUND,
+            percentile_filter=PERCENTILE_FILTER, percentile_threshold=PERCENTILE_THRESHOLD,
+            group_filter=last,only,
+            reproject=REPROJECT,
+            save_pointcloud=SAVE_POINTCLOUD,
+            pointcloud_file='pointcloud',
+            input_crs = POINTCLOUD_CRS[i],
+            output_crs=OUTPUT_CRS,
+            output_type=OUTPUT_TYPE
+        )
         dem_stage = dsm_functions.create_dem_stage(dem_filename=str(dem_file),
                                         pointcloud_resolution=POINTCLOUD_RESOLUTION,
                                         gridmethod=GRID_METHOD, dimension=DIMENSION)

--- a/src/grid_pc/pdal_pipeline.py
+++ b/src/grid_pc/pdal_pipeline.py
@@ -1,6 +1,7 @@
 """
 Generate a DSM from input polygon
 """
+import os
 from grid_pc import dsm_functions
 import pdal
 from shapely.geometry import Polygon
@@ -126,7 +127,9 @@ def create_dsm(extent_geojson: str, # processing_extent.geojson
         pipeline['pipeline'] += dem_stage
 
         # Save a copy of each pipeline
-        with open(f'/tmp/dem/pipeline_{str(i).zfill(4)}.json', 'w') as f:
+        pipeline_config_fn = os.path.join(output_path,f"pipeline_{i}.json")
+        
+        with open(pipeline_config_fn, 'w') as f:
             f.write(json.dumps(pipeline))
 
         # Skip execution for testing

--- a/src/grid_pc/pdal_pipeline.py
+++ b/src/grid_pc/pdal_pipeline.py
@@ -11,8 +11,8 @@ from pathlib import Path
 # NOTE: Hardcoding global settings for now, can expose as script arguments later
 # -------------------------------------------------------
 # Set pointcloud processing parameters
-FILTER_LOW_NOISE = True
-FILTER_HIGH_NOISE = True
+FILTER_LOW_NOISE = False
+FILTER_HIGH_NOISE = False
 FILTER_ROAD = False
 RETURN_ONLY_GROUND = False # Set true for DTM
 RESET_CLASSES = False
@@ -30,6 +30,7 @@ POINTCLOUD_RESOLUTION = 1
 OUTPUT_TYPE='laz'
 GRID_METHOD='idw'
 DIMENSION='Z' # can be set to options accepted by writers.gdal. Set to 'intensity' to return intensity rasters
+
 # -------------------------------------------------------
 
 
@@ -118,8 +119,8 @@ def create_dsm(extent_geojson: str, # processing_extent.geojson
                                         pointcloud_resolution=POINTCLOUD_RESOLUTION,
                                         gridmethod=GRID_METHOD, dimension=DIMENSION)
 
-        # apply interpolation to fill gaps when generating DSM/DTM
-        dem_stage[0]['window_size'] = 4
+        # this is only required for the DTM, since this function is for a DSM, I am commenting this out
+        #dem_stage[0]['window_size'] = 4
 
         pipeline['pipeline'] += pdal_pipeline
         pipeline['pipeline'] += dem_stage

--- a/src/grid_pc/pdal_pipeline.py
+++ b/src/grid_pc/pdal_pipeline.py
@@ -168,7 +168,7 @@ def create_dsm(extent_geojson: str, # processing_extent.geojson
 
         ## Intensity pipeline
         pipeline_intensity = {'pipeline':[reader]}
-        pdal_pipeline_surface_intesity = dsm_functions.create_pdal_pipeline(
+        pdal_pipeline_surface_intensity = dsm_functions.create_pdal_pipeline(
             filter_low_noise=FILTER_LOW_NOISE,
             filter_high_noise=FILTER_HIGH_NOISE,
             filter_road=FILTER_ROAD,


### PR DESCRIPTION
Through this PR, we now have:
* Updated the defaults in the functions
* Incorporated the feedback received [here](https://github.com/uw-cryo/stereo-lidar_archive_search/issues/20)
* Add DTM and intensity raster creation functions, so that we get all three rasters for a given site
* I am also attaching the pipeline for the three products which are written to disk so that it is easier to review and verify.
* Added a smaller aoi which has vegetation, bare ground and slope, and makes testing quicker.
* There is no filtering turned on by default, as it will be site/acquisition specific.

[pipeline_dsm_0004.json](https://github.com/user-attachments/files/18522035/pipeline_dsm_0004.json)
[pipeline_dtm_0004.json](https://github.com/user-attachments/files/18522037/pipeline_dtm_0004.json)
[pipeline_intensity_0004.json](https://github.com/user-attachments/files/18522038/pipeline_intensity_0004.json)

